### PR TITLE
Fix installation for Kwin 6 (#24)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build: package
 
 install: build
 	kpackagetool6 -t KWin/Script -s $(PROJECT_NAME) \
-		&& kpackagetool6 -u $(PKGFILE) \
-		|| kpackagetool6 -i $(PKGFILE)	
+		&& kpackagetool6 -t KWin/Script -u $(PKGFILE) \
+		|| kpackagetool6 -t KWin/Script -i $(PKGFILE)	
 
 uninstall:
 	kpackagetool6 -t KWin/Script -r $(PROJECT_NAME)


### PR DESCRIPTION
make install was not installing the files in the correct place, which meant that the script no longer worked. The reason is because the type was not being passed to the install and update commands, and so the default type was being used.